### PR TITLE
wgpu branch: Tested X11 support and untested MacOS support

### DIFF
--- a/Robust.Client/Graphics/Clyde/Rhi/RhiWebGpu.Window.cs
+++ b/Robust.Client/Graphics/Clyde/Rhi/RhiWebGpu.Window.cs
@@ -19,6 +19,7 @@ internal sealed unsafe partial class RhiWebGpu
         SurfaceDescriptor surfaceDesc = default;
         SurfaceDescriptorFromWindowsHWND surfaceDescHwnd;
         SurfaceDescriptorFromXlibWindow surfaceDescX11;
+        SurfaceDescriptorFromMetalLayer surfaceDescMetal;
 
         if (OperatingSystem.IsWindows())
         {
@@ -58,7 +59,25 @@ internal sealed unsafe partial class RhiWebGpu
             }
             else
             {
-                throw new NotImplementedException();
+                var metalLayer = _clyde._windowing.WindowGetMetalLayer(window);
+
+                if (metalLayer != null)
+                {
+                    surfaceDescMetal = new SurfaceDescriptorFromMetalLayer
+                    {
+                        Chain =
+                        {
+                            SType = SType.SurfaceDescriptorFromMetalLayer
+                        },
+                        Layer = ((IntPtr) metalLayer.Value).ToPointer()
+                    };
+
+                    surfaceDesc.NextInChain = (ChainedStruct*) (&surfaceDescMetal);
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
             }
         }
 

--- a/Robust.Client/Graphics/Clyde/Rhi/RhiWebGpu.cs
+++ b/Robust.Client/Graphics/Clyde/Rhi/RhiWebGpu.cs
@@ -56,7 +56,7 @@ internal sealed unsafe partial class RhiWebGpu : RhiBase
 
     private void InitInstance()
     {
-        var context = WebGPU.CreateDefaultContext(new[] { "wgpu_native.dll" });
+        var context = WebGPU.CreateDefaultContext(new[] { "wgpu_native.dll", "libwgpu_native.so", "libwgpu_native.dylib" });
         _webGpu = new WebGPU(context);
         _wgpu = new Wgpu(context);
 

--- a/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Glfw.Windows.cs
@@ -222,6 +222,10 @@ namespace Robust.Client.Graphics.Clyde
                 }
             }
 
+            // GLFW doesn't have the Metal view/layer API that SDL2 does.
+            // It might be possible though.
+            public nint? WindowGetMetalLayer(WindowReg window) => null;
+
             public HWND WindowGetWin32Window(WindowReg window)
             {
                 if (!OperatingSystem.IsWindows())

--- a/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/IWindowingImpl.cs
@@ -43,6 +43,7 @@ namespace Robust.Client.Graphics.Clyde
             void WindowSwapBuffers(WindowReg window);
             uint? WindowGetX11Id(WindowReg window);
             nint? WindowGetX11Display(WindowReg window);
+            nint? WindowGetMetalLayer(WindowReg window);
             HWND WindowGetWin32Window(WindowReg window);
             HINSTANCE WindowGetWin32Instance(WindowReg window);
 

--- a/Robust.Client/Graphics/Clyde/Windowing/Sdl2.WindowThread.cs
+++ b/Robust.Client/Graphics/Clyde/Windowing/Sdl2.WindowThread.cs
@@ -219,6 +219,7 @@ internal partial class Clyde
 
         private sealed record CmdWinDestroy(
             nint Window,
+            nint MetalView,
             bool HadOwner
         ) : CmdBase;
 


### PR DESCRIPTION
If nothing else, this is early preparation for the Redwood test run.
Here on Raven2:
![image](https://github.com/PJB3005/space-station-14/assets/22304167/5aa3d882-21a7-415a-ada3-ae89f8361913)

The macOS support is untested, and is SDL2-only (it might be possible to get it to work with GLFW, but it's almost certain that awkwardly poking Mac stuff will be necessary). I *may* be able to rope someone in to test it if I look hard enough.